### PR TITLE
Expected char error is not defined fix

### DIFF
--- a/Linux_Shell.sh
+++ b/Linux_Shell.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-python src/shell.py
+python3 src/shell.py

--- a/src/expected_char_error.py
+++ b/src/expected_char_error.py
@@ -5,3 +5,7 @@
 # Rusted Studio - Development Studio
 
 from rustedscript import *
+
+class ExpectedCharError(Error):
+    def __init__(self, pos_start, pos_end, details=''):
+        super().__init__(pos_start, pos_end, 'Expected Character', details)


### PR DESCRIPTION
# Expected char error is not defined fix

## What I did
I edited the `src/expected_char_error.py` to the normal class, how you define errors, I looked at other error files. I also made a little change in Linux_Shell.sh, because linux requires Python 3+ files to be ran with `python3`.

And again, thanks in advance. 