### PR TITLE
Fix for Illegal Character Error

### DIFF
--- a/src/rustedscript.py
+++ b/src/rustedscript.py
@@ -9,6 +9,7 @@ from token_types import *
 from class_error import *
 from expected_char_error import *
 from invalid_syntax_error import *
+from illegal_char_error import *
 from rterror import *
 from position import *
 from token import *


### PR DESCRIPTION
# Fix for Illegal Character Error
Following my last pull request regarding this fix, now we import the illegal_char_error.py in the main rustedscript.py file, and now if we run something that produces this error, such as `var a = "hello"`, instead of the program terminating, now it will display an error like the below,
```
Illegal Character: '"'
File <stdin>, line 1
``` 
Before the program would error out. Im waiting for string support!
Again, thanks in advance.