### PR TITLE
Support for comments

### DIFF
--- a/docs/comments.md
+++ b/docs/comments.md
@@ -1,0 +1,8 @@
+# Comments In Rusted Script
+You can add comments to .rusted files anywhere! Here is a code example;
+```rusted
+// This is a comment
+ # This is a comment
+/* This is a comment
+```
+All of the above are valid ways to write comments in Rusted Script!

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -6,15 +6,25 @@ with open(sys.argv[1]) as rustedfile: # open the rusted file
 	print("    Running {}".format(sys.argv[1])+'...\n')
 	lines = rustedfile.readlines()
 	for line in lines:
-		result, error = rustedscript.run('<stdin>', line[0:len(line)-1])
-		if error:
-			print(error.as_string())
-			print("\n---- \n FATAL: Process exited with non-zero exit code")
-			sys.exit(1)
-		elif result:
-			print(result)
-			print("\n---- \n SUCCESS: {} ran successfully".format(sys.argv[1]))
-			sys.exit(0)
+		indexOfComment = int( line.find("//") )
+		if indexOfComment == -1:
+			indexOfComment = int( line.find("#") )
+		if indexOfComment == -1:
+			indexOfComment = int( line.find("/*") )
+		if indexOfComment != -1:
+			newline=line[0:indexOfComment-1]
+		else:
+			newline=line
+		if newline:
+			result, error = rustedscript.run('<stdin>', newline[0:len(line)-1])
+			if error:
+				print(error.as_string())
+				print("\n---- \n FATAL: Process exited with non-zero exit code")
+				sys.exit(1)
+			elif result:
+				print(result)
+				print("\n---- \n SUCCESS: {} ran successfully".format(sys.argv[1]))
+				sys.exit(0)
 
 
 


### PR DESCRIPTION
# Support for comments
Rusted Script can support comments!
```rusted
// this is a comment
# this is a comment
/* this is a comment */
```

# What I did

I made the following changes;

## `src/interpreter.py`
I edited the `src/interpreter.py` file and made it ignore characters after one of the following; `// OR # OR /* */`. If we run a *.rusted* file, that contains the code below,
```rusted
if 1 == 1 then 123 else 321 // this will be ignored
```
it will output the following,
```sh
$ python3 src/interpreter.py src/test.rusted
    Running test.rusted...

123

-----
     Success: test.rusted ran successfully
```

## `docs/comments.md`
I created a new file named `docs/comments.md`, its a guide on how to comment in *Rusted Script*

Thanks In Advance!
